### PR TITLE
Refactor API project ordering and access scope for admins

### DIFF
--- a/src/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/src/app/Http/Controllers/Api/V1/ProjectController.php
@@ -99,7 +99,7 @@ class ProjectController extends Controller
             'tags.*' => 'string|exists:project_tag,slug',
             'version_tags' => 'nullable|array',
             'version_tags.*' => 'string|exists:project_version_tag,slug',
-            'order_by' => 'nullable|string|in:name,created_at,latest_version,downloads',
+            'order_by' => 'nullable|string|in:name,created_at,updated_at,downloads',
             'order_direction' => 'nullable|string|in:asc,desc',
             'per_page' => 'nullable|integer|in:10,25,50,100',
             'release_date_period' => 'nullable|string|in:all,last_30_days,last_90_days,last_year,custom',

--- a/src/app/Http/Resources/ProjectResource.php
+++ b/src/app/Http/Resources/ProjectResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
 
 class ProjectResource extends JsonResource
 {
@@ -53,10 +54,16 @@ class ProjectResource extends JsonResource
             'last_release_date' => $this->recentReleaseDate?->toDateString(),
             'version_count' => $this->when($this->whenLoaded('versions'), fn () => $this->versions->count()),
             /**
+             * Last update time of the project or one of its versions
              * @var string | null
-             * @format date
+             * @format datetime
              */
-            'created_at' => $this->created_at?->toDateString(),
+            'updated_at' => Carbon::parse($this->last_update_time)->toDateTimeString(),
+            /**
+             * @var string | null
+             * @format datetime
+             */
+            'created_at' => Carbon::parse($this->created_at)->toDateTimeString(),
         ];
     }
 }

--- a/src/app/Models/Project.php
+++ b/src/app/Models/Project.php
@@ -220,19 +220,24 @@ class Project extends Model
         $user = Auth::user();
 
         // Return only approved projects and non-deactivated projects by default
+        // If the user is a admin, no restrictions apply
         // If the user is a member of the project, no restrictions apply
         if ($user) {
-            $query->where(function (Builder $query) use ($user) {
-                // Show approved and non-deactivated projects to everyone
-                $query->where(function (Builder $query) {
-                    $query->approved()
-                        ->whereNull('deactivated_at');
-                })
-                // OR show projects where the user is a member (regardless of status)
-                ->orWhereHas('memberships', function (Builder $query) use ($user) {
-                    $query->where('user_id', $user->id);
+            if ($user->isAdmin()) {
+                return;
+            }else{
+                $query->where(function (Builder $query) use ($user) {
+                    // Show approved and non-deactivated projects to everyone
+                    $query->where(function (Builder $query) {
+                        $query->approved()
+                            ->whereNull('deactivated_at');
+                    })
+                    // OR show projects where the user is a member (regardless of status)
+                    ->orWhereHas('memberships', function (Builder $query) use ($user) {
+                        $query->where('user_id', $user->id);
+                    });
                 });
-            });
+            }
         } else {
             // Guest users only see approved and non-deactivated projects
             $query->approved()

--- a/src/app/Models/Project.php
+++ b/src/app/Models/Project.php
@@ -247,6 +247,12 @@ class Project extends Model
     {
         $query->withSum('versions as downloads', 'downloads');
         $query->withMax('versions as recent_release_date', 'release_date');
+        // Add last update time as the greatest of the project updated_at and the maximum of all version updated_at
+        $query->addSelect([
+            'last_update_time' => ProjectVersion::selectRaw(
+                'GREATEST(project.updated_at, COALESCE(MAX(project_version.updated_at), project.updated_at))'
+            )->whereColumn('project_version.project_id', 'project.id'),
+        ]);
     }
 
     /**

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -46,12 +46,5 @@ class AppServiceProvider extends ServiceProvider
         if($this->app->environment('production')) {
             \URL::forceScheme('https');
         }
-
-        // TODO: Add description to the API documentation
-        Scramble::configure()
-            ->withDocumentTransformers(function (OpenApi $document) {
-                $document->info->description = '# TODO';
-            })
-        ;
     }
 }

--- a/src/app/Services/ProjectService.php
+++ b/src/app/Services/ProjectService.php
@@ -119,8 +119,8 @@ class ProjectService
                 return $query->orderBy('name', $orderDirection);
             case 'created_at':
                 return $query->orderBy('created_at', $orderDirection);
-            case 'latest_version':
-                return $query->orderBy('recent_release_date', $orderDirection);
+            case 'updated_at':
+                return $query->orderBy('last_update_time', $orderDirection);
             case 'downloads':
             default:
                 return $query->orderBy('downloads', $orderDirection);
@@ -171,7 +171,7 @@ class ProjectService
         return [
             ['id' => 'name', 'name' => 'Project Name', 'icon' => 'lucide-text'],
             ['id' => 'created_at', 'name' => 'Creation Date', 'icon' => 'lucide-calendar'],
-            ['id' => 'latest_version', 'name' => 'Update Date', 'icon' => 'lucide-refresh-cw'],
+            ['id' => 'updated_at', 'name' => 'Update Date', 'icon' => 'lucide-refresh-cw'],
             ['id' => 'downloads', 'name' => 'Downloads', 'icon' => 'lucide-download'],
         ];
     }

--- a/src/config/scramble.php
+++ b/src/config/scramble.php
@@ -29,7 +29,7 @@ return [
         /*
          * Description rendered on the home page of the API documentation (`/docs/api`).
          */
-        'description' => '',
+        'description' => "## Introduction\n\nThe **Hub01 Shop API** enables users to interact programmatically with the platform, allowing you to explore projects and manage your own resources.\n\nYou can query all available resources in the application, but currently, management capabilities are limited to project versions. Future updates will expand support for managing additional resources.\n\n---\n\n## Authentication\n\nAccess to certain API endpoints requires authentication using **API tokens**. These tokens can be generated directly from your user profile.\n\n---\n\n### Generating API Tokens\n\n1. **Navigate** to your user profile.\n2. **Select** the **API Tokens** section.\n3. **Click** on **Create API Token**.\n4. **Provide** a custom name and, optionally, set an expiration date.\n5. **Include** the generated token in the `Authorization` header of your API requests as a **Bearer token**.",
     ],
 
     /*

--- a/src/public/api.json
+++ b/src/public/api.json
@@ -160,7 +160,7 @@
                             "enum": [
                                 "name",
                                 "created_at",
-                                "latest_version",
+                                "updated_at",
                                 "downloads"
                             ],
                             "default": "downloads"
@@ -1913,12 +1913,20 @@
                         "type": "integer",
                         "minimum": 0
                     },
+                    "updated_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "datetime",
+                        "description": "Last update time of the project or one of its versions"
+                    },
                     "created_at": {
                         "type": [
                             "string",
                             "null"
                         ],
-                        "format": "date"
+                        "format": "datetime"
                     }
                 },
                 "required": [
@@ -1933,6 +1941,7 @@
                     "status",
                     "downloads",
                     "last_release_date",
+                    "updated_at",
                     "created_at"
                 ],
                 "title": "ProjectResource"

--- a/src/resources/views/components/project-card.blade.php
+++ b/src/resources/views/components/project-card.blade.php
@@ -69,10 +69,10 @@
                 </span>
             </div>
 
-            @if ($project->recent_release_date)
+            @if ($project->last_update_time)
                 <div class="flex items-center gap-1">
                     <x-icon name="lucide-calendar" class="w-3 h-3" />
-                    <span>Updated {{ \Carbon\Carbon::parse($project->recent_release_date)->diffForHumans() }}</span>
+                    <span>Updated {{ \Carbon\Carbon::parse($project->last_update_time)->diffForHumans() }}</span>
                 </div>
             @endif
 
@@ -158,14 +158,13 @@
                     </span>
                 </div>
 
-                @php
-                    $recentReleaseDate = $project->recent_release_date ?? $project->created_at;
-                @endphp
-                <div class="flex items-center gap-2">
-                    <x-icon name="lucide-calendar" />
-                    <span>Updated
-                        {{ \Carbon\Carbon::parse($recentReleaseDate)->diffForHumans() }}</span>
-                </div>
+                @if ($project->last_update_time)
+                    <div class="flex items-center gap-2">
+                        <x-icon name="lucide-calendar" />
+                        <span>Updated
+                            {{ \Carbon\Carbon::parse($project->last_update_time)->diffForHumans() }}</span>
+                    </div>
+                @endif
 
                 <div class="flex items-center gap-2">
                     <x-icon name="lucide-calendar-plus" />

--- a/src/tests/Unit/ProjectServiceTest.php
+++ b/src/tests/Unit/ProjectServiceTest.php
@@ -523,7 +523,7 @@ class ProjectServiceTest extends TestCase
         $this->assertContains('name', $optionIds);
         $this->assertContains('downloads', $optionIds);
         $this->assertContains('created_at', $optionIds);
-        $this->assertContains('latest_version', $optionIds);
+        $this->assertContains('updated_at', $optionIds);
     }
 
     #[Test]


### PR DESCRIPTION
refactor(api): replace latest_version with updated_at for project ordering
Calculate last_update_time as the greatest of project updated_at and all version updated_at times.

docs(api): add API documentation description

fix(Project): add admin bypass to access scope restrictions
This change modifies the accessScope method in the Project model to bypass query restrictions for admin users.
