### PR TITLE
fix(Project): revert to using release dates and keep project updated_…

### DIFF
--- a/src/app/Models/Project.php
+++ b/src/app/Models/Project.php
@@ -252,10 +252,10 @@ class Project extends Model
     {
         $query->withSum('versions as downloads', 'downloads');
         $query->withMax('versions as recent_release_date', 'release_date');
-        // Add last update time as the greatest of the project updated_at and the maximum of all version updated_at
+        // Add last update time as the greatest of the project updated_at and the maximum of all version release dates
         $query->addSelect([
             'last_update_time' => ProjectVersion::selectRaw(
-                'GREATEST(project.updated_at, COALESCE(MAX(project_version.updated_at), project.updated_at))'
+                'GREATEST(project.updated_at, COALESCE(MAX(project_version.release_date), project.updated_at))'
             )->whereColumn('project_version.project_id', 'project.id'),
         ]);
     }


### PR DESCRIPTION
…at fallback

if we use updated_at from the versions, just trigering a download will update the stat. Consider moving the downloads to a specific table or other approach