### PR TITLE
feat(tags): add display priority for tags and groups

### DIFF
--- a/src/app/Livewire/Admin/TagGroupManagement.php
+++ b/src/app/Livewire/Admin/TagGroupManagement.php
@@ -19,6 +19,8 @@ class TagGroupManagement extends Component
 
     public $tagGroupProjectTypes = [];
 
+    public int $tagGroupDisplayPriority = 0;
+
     public $isEditingTagGroup = false;
 
     // Modal state
@@ -35,6 +37,7 @@ class TagGroupManagement extends Component
             'tagGroupName' => 'required|string|max:50',
             'tagGroupSlug' => 'required|string|max:50|unique:project_tag_group,slug,' . $this->tagGroupId,
             'tagGroupProjectTypes' => 'required|array',
+            'tagGroupDisplayPriority' => 'required|integer|min:0',
         ];
     }
 
@@ -69,6 +72,7 @@ class TagGroupManagement extends Component
         $this->tagGroupId = $tagGroup->id;
         $this->tagGroupName = $tagGroup->name;
         $this->tagGroupSlug = $tagGroup->slug;
+        $this->tagGroupDisplayPriority = $tagGroup->display_priority;
         $this->tagGroupProjectTypes = $tagGroup->projectTypes->pluck('id')->toArray();
         $this->isEditingTagGroup = true;
         $this->showModal = true;
@@ -82,6 +86,7 @@ class TagGroupManagement extends Component
             $tagGroup = ProjectTagGroup::find($this->tagGroupId);
             $tagGroup->name = $this->tagGroupName;
             $tagGroup->slug = $this->tagGroupSlug;
+            $tagGroup->display_priority = $this->tagGroupDisplayPriority;
             $tagGroup->save();
 
             // Sync project types
@@ -92,6 +97,7 @@ class TagGroupManagement extends Component
             $tagGroup = ProjectTagGroup::create([
                 'name' => $this->tagGroupName,
                 'slug' => $this->tagGroupSlug,
+                'display_priority' => $this->tagGroupDisplayPriority,
             ]);
 
             // Sync project types
@@ -109,6 +115,7 @@ class TagGroupManagement extends Component
         $this->tagGroupId = null;
         $this->tagGroupName = '';
         $this->tagGroupSlug = '';
+        $this->tagGroupDisplayPriority = 0;
         $this->tagGroupProjectTypes = [];
         $this->isEditingTagGroup = false;
     }

--- a/src/app/Livewire/Admin/TagManagement.php
+++ b/src/app/Livewire/Admin/TagManagement.php
@@ -24,6 +24,8 @@ class TagManagement extends Component
 
     public ?int $tagParentId = null;
 
+    public int $tagDisplayPriority = 0;
+
     public $tagProjectTypes = [];
 
     public $isEditingTag = false;
@@ -46,6 +48,7 @@ class TagManagement extends Component
             'projectTagSlug' => 'required|string|max:50|unique:project_tag,slug,' . $this->tagId,
             'tagIcon' => 'required|string|max:50|starts_with:lucide-',
             'tagParentId' => 'nullable|exists:project_tag,id',
+            'tagDisplayPriority' => 'required|integer|min:0',
         ];
     }
 
@@ -91,6 +94,7 @@ class TagManagement extends Component
         $this->tagIcon = $tag->icon;
         $this->tagGroupId = $tag->project_tag_group_id;
         $this->tagParentId = $tag->parent_id;
+        $this->tagDisplayPriority = $tag->display_priority;
         $this->tagProjectTypes = $tag->projectTypes->pluck('id')->toArray();
         $this->isEditingTag = true;
         $this->showModal = true;
@@ -107,6 +111,7 @@ class TagManagement extends Component
             $tag->icon = $this->tagIcon;
             $tag->project_tag_group_id = $this->tagGroupId;
             $tag->parent_id = $this->tagParentId;
+            $tag->display_priority = $this->tagDisplayPriority;
             $tag->save();
 
             // Sync project types
@@ -120,6 +125,7 @@ class TagManagement extends Component
                 'icon' => $this->tagIcon,
                 'project_tag_group_id' => $this->tagGroupId,
                 'parent_id' => $this->tagParentId,
+                'display_priority' => $this->tagDisplayPriority,
             ]);
 
             // Sync project types
@@ -140,6 +146,7 @@ class TagManagement extends Component
         $this->tagIcon = 'lucide-tag';
         $this->tagGroupId = null;
         $this->tagParentId = null;
+        $this->tagDisplayPriority = 0;
         $this->tagProjectTypes = [];
         $this->isEditingTag = false;
     }

--- a/src/app/Livewire/Admin/VersionTagGroupManagement.php
+++ b/src/app/Livewire/Admin/VersionTagGroupManagement.php
@@ -19,6 +19,8 @@ class VersionTagGroupManagement extends Component
 
     public $versionTagGroupProjectTypes = [];
 
+    public int $versionTagGroupDisplayPriority = 0;
+
     public $isEditingVersionTagGroup = false;
 
     // Modal state
@@ -35,6 +37,7 @@ class VersionTagGroupManagement extends Component
             'versionTagGroupName' => 'required|string|max:50',
             'versionTagGroupSlug' => 'required|string|max:50|unique:project_version_tag_group,slug,' . $this->versionTagGroupId,
             'versionTagGroupProjectTypes' => 'required|array',
+            'versionTagGroupDisplayPriority' => 'required|integer|min:0',
         ];
     }
 
@@ -69,6 +72,7 @@ class VersionTagGroupManagement extends Component
         $this->versionTagGroupId = $versionTagGroup->id;
         $this->versionTagGroupName = $versionTagGroup->name;
         $this->versionTagGroupSlug = $versionTagGroup->slug;
+        $this->versionTagGroupDisplayPriority = $versionTagGroup->display_priority;
         $this->versionTagGroupProjectTypes = $versionTagGroup->projectTypes->pluck('id')->toArray();
         $this->isEditingVersionTagGroup = true;
         $this->showModal = true;
@@ -82,6 +86,7 @@ class VersionTagGroupManagement extends Component
             $versionTagGroup = ProjectVersionTagGroup::find($this->versionTagGroupId);
             $versionTagGroup->name = $this->versionTagGroupName;
             $versionTagGroup->slug = $this->versionTagGroupSlug;
+            $versionTagGroup->display_priority = $this->versionTagGroupDisplayPriority;
             $versionTagGroup->save();
 
             // Sync project types
@@ -92,6 +97,7 @@ class VersionTagGroupManagement extends Component
             $versionTagGroup = ProjectVersionTagGroup::create([
                 'name' => $this->versionTagGroupName,
                 'slug' => $this->versionTagGroupSlug,
+                'display_priority' => $this->versionTagGroupDisplayPriority,
             ]);
 
             // Sync project types
@@ -109,6 +115,7 @@ class VersionTagGroupManagement extends Component
         $this->versionTagGroupId = null;
         $this->versionTagGroupName = '';
         $this->versionTagGroupSlug = '';
+        $this->versionTagGroupDisplayPriority = 0;
         $this->versionTagGroupProjectTypes = [];
         $this->isEditingVersionTagGroup = false;
     }

--- a/src/app/Livewire/Admin/VersionTagManagement.php
+++ b/src/app/Livewire/Admin/VersionTagManagement.php
@@ -24,6 +24,8 @@ class VersionTagManagement extends Component
 
     public ?int $versionTagParentId = null;
 
+    public int $versionTagDisplayPriority = 0;
+
     public $versionTagProjectTypes = [];
 
     public $isEditingVersionTag = false;
@@ -46,6 +48,7 @@ class VersionTagManagement extends Component
             'versionTagSlug' => 'required|string|max:50|unique:project_version_tag,slug,' . $this->versionTagId,
             'versionTagIcon' => 'required|string|max:50|starts_with:lucide-',
             'versionTagParentId' => 'nullable|exists:project_version_tag,id',
+            'versionTagDisplayPriority' => 'required|integer|min:0',
         ];
     }
 
@@ -91,6 +94,7 @@ class VersionTagManagement extends Component
         $this->versionTagIcon = $versionTag->icon;
         $this->versionTagGroupId = $versionTag->project_version_tag_group_id;
         $this->versionTagParentId = $versionTag->parent_id;
+        $this->versionTagDisplayPriority = $versionTag->display_priority;
         $this->versionTagProjectTypes = $versionTag->projectTypes->pluck('id')->toArray();
         $this->isEditingVersionTag = true;
         $this->showModal = true;
@@ -107,6 +111,7 @@ class VersionTagManagement extends Component
             $versionTag->icon = $this->versionTagIcon;
             $versionTag->project_version_tag_group_id = $this->versionTagGroupId;
             $versionTag->parent_id = $this->versionTagParentId;
+            $versionTag->display_priority = $this->versionTagDisplayPriority;
             $versionTag->save();
 
             // Sync project types
@@ -120,6 +125,7 @@ class VersionTagManagement extends Component
                 'icon' => $this->versionTagIcon,
                 'project_version_tag_group_id' => $this->versionTagGroupId,
                 'parent_id' => $this->versionTagParentId,
+                'display_priority' => $this->versionTagDisplayPriority,
             ]);
 
             // Sync project types
@@ -140,6 +146,7 @@ class VersionTagManagement extends Component
         $this->versionTagIcon = 'lucide-tag';
         $this->versionTagGroupId = null;
         $this->versionTagParentId = null;
+        $this->versionTagDisplayPriority = 0;
         $this->versionTagProjectTypes = [];
         $this->isEditingVersionTag = false;
     }

--- a/src/app/Models/ProjectTag.php
+++ b/src/app/Models/ProjectTag.php
@@ -30,8 +30,13 @@ class ProjectTag extends Model
         'name',
         'slug',
         'icon',
+        'display_priority',
         'project_tag_group_id',
         'parent_id',
+    ];
+
+    protected $casts = [
+        'display_priority' => 'integer',
     ];
 
     /**
@@ -41,6 +46,12 @@ class ProjectTag extends Model
      */
     protected static function booted()
     {
+        static::addGlobalScope('display_priority_order', function (Builder $builder) {
+            $builder
+                ->orderByDesc('display_priority')
+                ->orderBy('slug');
+        });
+
         // Clear the tags cache when a tag is created, updated, or deleted
         static::saved(function ($tag) {
             foreach (ProjectType::all() as $projectType) {

--- a/src/app/Models/ProjectTagGroup.php
+++ b/src/app/Models/ProjectTagGroup.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\HasUniqueSlug;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -27,7 +28,12 @@ class ProjectTagGroup extends Model
     protected $fillable = [
         'name',
         'slug',
-        'icon'
+        'icon',
+        'display_priority',
+    ];
+
+    protected $casts = [
+        'display_priority' => 'integer',
     ];
 
     /**
@@ -37,6 +43,11 @@ class ProjectTagGroup extends Model
      */
     protected static function booted()
     {
+        static::addGlobalScope('display_priority_order', function (Builder $builder) {
+            $builder
+                ->orderByDesc('display_priority')
+                ->orderBy('slug');
+        });
 
         static::saved(function ($tagGroup) {
             if ($tagGroup->projectTypes->isNotEmpty()) {

--- a/src/app/Models/ProjectVersionTag.php
+++ b/src/app/Models/ProjectVersionTag.php
@@ -30,8 +30,13 @@ class ProjectVersionTag extends Model
         'name',
         'slug',
         'icon',
+        'display_priority',
         'project_version_tag_group_id',
         'parent_id',
+    ];
+
+    protected $casts = [
+        'display_priority' => 'integer',
     ];
 
     /**
@@ -41,6 +46,12 @@ class ProjectVersionTag extends Model
      */
     protected static function booted()
     {
+        static::addGlobalScope('display_priority_order', function (Builder $builder) {
+            $builder
+                ->orderByDesc('display_priority')
+                ->orderBy('slug');
+        });
+
         static::saved(function ($tag) {
             foreach (ProjectType::all() as $projectType) {
                 Cache::forget('project_version_tags_by_type_'.$projectType->value);

--- a/src/app/Models/ProjectVersionTagGroup.php
+++ b/src/app/Models/ProjectVersionTagGroup.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\HasUniqueSlug;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -27,6 +28,11 @@ class ProjectVersionTagGroup extends Model
         'name',
         'slug',
         'icon',
+        'display_priority',
+    ];
+
+    protected $casts = [
+        'display_priority' => 'integer',
     ];
 
     /**
@@ -36,6 +42,12 @@ class ProjectVersionTagGroup extends Model
      */
     protected static function booted()
     {
+        static::addGlobalScope('display_priority_order', function (Builder $builder) {
+            $builder
+                ->orderByDesc('display_priority')
+                ->orderBy('slug');
+        });
+
         static::saved(function ($tagGroup) {
             if ($tagGroup->projectTypes->isNotEmpty()) {
                 foreach ($tagGroup->projectTypes as $projectType) {

--- a/src/app/Services/ProjectService.php
+++ b/src/app/Services/ProjectService.php
@@ -62,6 +62,7 @@ class ProjectService
         // Filter by project tags, ensuring all selected tags are present
         if (count($selectedTags)) {
             $projects->whereHas('tags', function ($query) use ($selectedTags) {
+                $query->withoutGlobalScope('display_priority_order');
                 $query->whereIn('tag_id', $selectedTags);
             }, '>=', count($selectedTags));
         }
@@ -73,6 +74,7 @@ class ProjectService
                 // Filter by version tags
                 if (count($selectedVersionTags)) {
                     $versionQuery->whereHas('tags', function ($tagQuery) use ($selectedVersionTags) {
+                        $tagQuery->withoutGlobalScope('display_priority_order');
                         $tagQuery->whereIn('tag_id', $selectedVersionTags);
                     }, '>=', count($selectedVersionTags));
                 }
@@ -736,4 +738,3 @@ class ProjectService
         }
     }
 }
-

--- a/src/app/Services/ProjectVersionService.php
+++ b/src/app/Services/ProjectVersionService.php
@@ -346,7 +346,7 @@ class ProjectVersionService
         ?string $releaseDateEnd = null,
         ?array $with = null
     ): \Illuminate\Contracts\Pagination\LengthAwarePaginator {
-        return $project->versions()
+        $query = $project->versions()
             ->with($with ?? [
                 'tags.tagGroup',
                 'project.projectType',
@@ -356,6 +356,8 @@ class ProjectVersionService
                 // Filter by version tags
                 if (!empty($selectedVersionTags)) {
                     $query->whereHas('tags', function (\Illuminate\Database\Eloquent\Builder $q) use ($selectedVersionTags) {
+                        $q->withoutGlobalScope('display_priority_order');
+
                         $q->whereIn('project_version_tag.id', $selectedVersionTags);
                     }, '>=', count($selectedVersionTags));
                 }
@@ -383,9 +385,11 @@ class ProjectVersionService
                         $query->where('release_date', '<=', $endDate);
                     }
                 }
-            })
-            ->orderBy($orderBy, $orderDirection)
-            ->paginate($perPage);
+            });
+
+        $query->orderBy($orderBy, $orderDirection);
+
+        return $query->paginate($perPage);
     }
 
     /**

--- a/src/database/factories/ProjectTagFactory.php
+++ b/src/database/factories/ProjectTagFactory.php
@@ -19,6 +19,7 @@ class ProjectTagFactory extends Factory
         return [
             'name' => fake()->unique()->word(),
             'icon' => 'lucide-tag',
+            'display_priority' => 0,
             'project_tag_group_id' => null,
             'created_at' => now(),
             'updated_at' => now(),

--- a/src/database/factories/ProjectTagGroupFactory.php
+++ b/src/database/factories/ProjectTagGroupFactory.php
@@ -18,6 +18,7 @@ class ProjectTagGroupFactory extends Factory
     {
         return [
             'name' => fake()->unique()->words(2, true),
+            'display_priority' => 0,
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/src/database/factories/ProjectVersionTagFactory.php
+++ b/src/database/factories/ProjectVersionTagFactory.php
@@ -19,6 +19,7 @@ class ProjectVersionTagFactory extends Factory
         return [
             'name' => fake()->unique()->word(),
             'icon' => 'lucide-tag',
+            'display_priority' => 0,
             'project_version_tag_group_id' => null,
             'created_at' => now(),
             'updated_at' => now(),

--- a/src/database/factories/ProjectVersionTagGroupFactory.php
+++ b/src/database/factories/ProjectVersionTagGroupFactory.php
@@ -18,6 +18,7 @@ class ProjectVersionTagGroupFactory extends Factory
     {
         return [
             'name' => fake()->unique()->words(2, true),
+            'display_priority' => 0,
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/src/database/migrations/2026_02_22_162300_add_display_priority_to_tag_tables.php
+++ b/src/database/migrations/2026_02_22_162300_add_display_priority_to_tag_tables.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_tag_group', function (Blueprint $table) {
+            $table->integer('display_priority')->default(0)->after('name');
+        });
+
+        Schema::table('project_tag', function (Blueprint $table) {
+            $table->integer('display_priority')->default(0)->after('icon');
+        });
+
+        Schema::table('project_version_tag_group', function (Blueprint $table) {
+            $table->integer('display_priority')->default(0)->after('name');
+        });
+
+        Schema::table('project_version_tag', function (Blueprint $table) {
+            $table->integer('display_priority')->default(0)->after('icon');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_version_tag', function (Blueprint $table) {
+            $table->dropColumn('display_priority');
+        });
+
+        Schema::table('project_version_tag_group', function (Blueprint $table) {
+            $table->dropColumn('display_priority');
+        });
+
+        Schema::table('project_tag', function (Blueprint $table) {
+            $table->dropColumn('display_priority');
+        });
+
+        Schema::table('project_tag_group', function (Blueprint $table) {
+            $table->dropColumn('display_priority');
+        });
+    }
+};

--- a/src/resources/views/livewire/admin/tag-group-management.blade.php
+++ b/src/resources/views/livewire/admin/tag-group-management.blade.php
@@ -48,6 +48,16 @@
 
             <x-input label="Slug" wire:model.live.debounce.500ms="tagGroupSlug" spinner="tagGroupName, tagGroupSlug" required />
 
+            <x-input
+                label="Display Priority"
+                type="number"
+                min="0"
+                step="1"
+                wire:model="tagGroupDisplayPriority"
+                hint="Lower values are shown first"
+                required
+            />
+
             <div class="form-control">
                 <label class="label">
                     <span class="label-text">Associated Project Types</span>

--- a/src/resources/views/livewire/admin/tag-management.blade.php
+++ b/src/resources/views/livewire/admin/tag-management.blade.php
@@ -109,6 +109,16 @@
                 hint="Select a parent tag to make this a sub-tag"
             />
 
+            <x-input
+                label="Display Priority"
+                type="number"
+                min="0"
+                step="1"
+                wire:model="tagDisplayPriority"
+                hint="Lower values are shown first"
+                required
+            />
+
             @if(!$tagParentId)
                 <x-select label="Tag Group" wire:model="tagGroupId" :options="$tagGroups"
                     placeholder="Select group (optional)" />

--- a/src/resources/views/livewire/admin/version-tag-group-management.blade.php
+++ b/src/resources/views/livewire/admin/version-tag-group-management.blade.php
@@ -50,6 +50,16 @@
 
             <x-input label="Slug" wire:model.live.debounce.500ms="versionTagGroupSlug" spinner="versionTagName, versionTagGroupSlug" required />
 
+            <x-input
+                label="Display Priority"
+                type="number"
+                min="0"
+                step="1"
+                wire:model="versionTagGroupDisplayPriority"
+                hint="Lower values are shown first"
+                required
+            />
+
             <div class="form-control">
                 <label class="label">
                     <span class="label-text">Associated Project Types</span>

--- a/src/resources/views/livewire/admin/version-tag-management.blade.php
+++ b/src/resources/views/livewire/admin/version-tag-management.blade.php
@@ -109,6 +109,16 @@
                 hint="Select a parent tag to make this a sub-tag"
             />
 
+            <x-input
+                label="Display Priority"
+                type="number"
+                min="0"
+                step="1"
+                wire:model="versionTagDisplayPriority"
+                hint="Lower values are shown first"
+                required
+            />
+
             @if(!$versionTagParentId)
                 <x-select label="Version Tag Group" wire:model="versionTagGroupId" :options="$versionTagGroups"
                     placeholder="Select group (optional)" />

--- a/src/tests/Feature/Api/VersionTagTest.php
+++ b/src/tests/Feature/Api/VersionTagTest.php
@@ -204,4 +204,61 @@ class VersionTagTest extends TestCase
         $this->assertCount(1, $data);
         $this->assertEquals($mainTag->slug, $data[0]['slug']);
     }
+
+    #[Test]
+    public function test_version_tags_are_ordered_by_priority_then_slug_and_do_not_expose_display_priority()
+    {
+        $mainAlpha = ProjectVersionTag::factory()->create([
+            'name' => 'Main Alpha',
+            'slug' => 'main-alpha',
+            'display_priority' => 10,
+        ]);
+        $mainAlpha->projectTypes()->attach($this->projectType);
+
+        $mainBeta = ProjectVersionTag::factory()->create([
+            'name' => 'Main Beta',
+            'slug' => 'main-beta',
+            'display_priority' => 10,
+        ]);
+        $mainBeta->projectTypes()->attach($this->projectType);
+
+        $mainLow = ProjectVersionTag::factory()->create([
+            'name' => 'Main Low',
+            'slug' => 'main-low',
+            'display_priority' => 1,
+        ]);
+        $mainLow->projectTypes()->attach($this->projectType);
+
+        $subB = ProjectVersionTag::factory()->create([
+            'name' => 'Sub B',
+            'slug' => 'sub-b',
+            'display_priority' => 7,
+            'parent_id' => $mainAlpha->id,
+        ]);
+        $subB->projectTypes()->attach($this->projectType);
+
+        $subA = ProjectVersionTag::factory()->create([
+            'name' => 'Sub A',
+            'slug' => 'sub-a',
+            'display_priority' => 7,
+            'parent_id' => $mainAlpha->id,
+        ]);
+        $subA->projectTypes()->attach($this->projectType);
+
+        $response = $this->getJson('/api/v1/version_tags');
+        $response->assertOk();
+
+        $data = $response->json('data');
+
+        $this->assertSame(['main-alpha', 'main-beta', 'main-low'], array_column($data, 'slug'));
+        $this->assertSame(['sub-a', 'sub-b'], array_column($data[0]['sub_tags'], 'slug'));
+
+        foreach ($data as $tag) {
+            $this->assertArrayNotHasKey('display_priority', $tag);
+
+            foreach ($tag['sub_tags'] ?? [] as $subTag) {
+                $this->assertArrayNotHasKey('display_priority', $subTag);
+            }
+        }
+    }
 }


### PR DESCRIPTION
introduce `display_priority` for project tags, version tags, and both group types with a new migration and factory defaults.

add admin Livewire form fields and validation so priorities can be set and edited for tags and groups.

apply default model ordering by `display_priority` (desc) then `slug` for deterministic API and service output, and cast priority as integer.

update project search tag filters to bypass the ordering global scope in `whereHas` clauses to keep tag matching behavior correct.

expand API and service tests to verify ordering behavior and confirm `display_priority` is not exposed in API responses.