### PR TITLE
feat(download-analytics): deduplicate file download counting and migrate totals to daily aggregates

### DIFF
--- a/docs/download-count-improvements-summary.md
+++ b/docs/download-count-improvements-summary.md
@@ -1,0 +1,80 @@
+# Download Count Improvements — Change Summary
+
+## Scope delivered
+
+Feature implementation for download counting improvements with anti-spam deduplication, user profile aggregation, and migration to daily downloads as the single source of truth.
+
+## Main behavior changes
+
+### 1) Download counting flow
+
+- File downloads are still served even when a request is deduplicated.
+- Download counting is deduplicated for 3 hours using a fingerprint from requester IP + user agent (+ entity context in key).
+- Missing-file requests do not increment download stats.
+- Counting now writes to daily download rows only.
+
+## Data model and migrations
+
+### 2) Daily time-series storage
+
+- Added daily table for version downloads:
+    - `project_version_daily_download`
+    - Unique key: `(project_version_id, date)`
+
+### 3) Backfill legacy totals to daily rows
+
+- Added migration to migrate old `project_version.downloads` totals into daily rows.
+- Distribution strategy:
+    - Range: version creation date -> today (inclusive)
+    - Even-as-possible allocation via base + remainder
+    - Deterministic allocation order
+- Uses chunked processing and upsert conflict handling.
+
+### 4) Remove deprecated legacy column
+
+- Added migration to drop `project_version.downloads`.
+- Rollback re-adds the column with safe default.
+
+## Domain/query changes
+
+### 5) Models and scopes
+
+- Reverted temporary “legacy + daily composed accessors” work.
+- `ProjectVersion` download semantics now rely on daily rows only.
+- `Project::withStats()` now aggregates downloads from daily rows only.
+
+### 6) Application surfaces updated to daily-only stats
+
+- Download controller increment path.
+- Admin dashboard download metrics.
+- User profile aggregate downloads.
+- Project/version listing and sorting logic using downloads.
+
+## Tests updated
+
+- Feature and unit tests were updated to daily-only behavior.
+- Obsolete temporary test for combined legacy+daily totals was removed.
+- Targeted suites for controller/profile/API/search/service download behavior were run and passed.
+
+## Files touched (high level)
+
+- Migrations:
+    - `src/database/migrations/2026_02_24_180000_create_project_version_daily_download_table.php`
+    - `src/database/migrations/2026_02_24_181000_backfill_project_version_downloads_to_daily_downloads.php`
+    - `src/database/migrations/2026_02_24_182000_drop_downloads_from_project_version_table.php`
+- Models/services/controllers/livewire (download stats consumers):
+    - `src/app/Http/Controllers/FileDownloadController.php`
+    - `src/app/Models/ProjectVersion.php`
+    - `src/app/Models/Project.php`
+    - `src/app/Services/ProjectVersionService.php`
+    - `src/app/Livewire/Admin/Dashboard.php`
+    - `src/app/Livewire/UserProfile.php`
+- Tests/factory:
+    - `src/tests/Feature/Project/Http/Controllers/FileDownloadControllerTest.php`
+    - `src/tests/Feature/User/Livewire/UserProfileTest.php`
+    - `src/tests/Feature/Api/ProjectTest.php`
+    - `src/tests/Feature/Api/ProjectVersionTest.php`
+    - `src/tests/Feature/Project/Livewire/ProjectSearchTest.php`
+    - `src/tests/Unit/ProjectServiceTest.php`
+    - `src/database/factories/ProjectVersionFactory.php`
+    - removed: `src/tests/Unit/ProjectDownloadStatsTest.php`

--- a/src/app/Http/Controllers/FileDownloadController.php
+++ b/src/app/Http/Controllers/FileDownloadController.php
@@ -7,6 +7,7 @@ use App\Models\ProjectFile;
 use App\Models\ProjectType;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -56,14 +57,22 @@ class FileDownloadController extends Controller
         $shouldCount = Cache::add($dedupeKey, true, now()->addHours(3));
 
         if ($shouldCount) {
-            $version->increment('downloads');
-
-            $dailyDownload = $version->dailyDownloads()->firstOrCreate(
-                ['date' => today()->toDateString()],
-                ['downloads' => 0]
+            $now = now();
+            $today = $now->toDateString();
+            DB::table('project_version_daily_download')->upsert(
+                [[
+                    'project_version_id' => $version->id,
+                    'date' => $today,
+                    'downloads' => 1,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]],
+                ['project_version_id', 'date'],
+                [
+                    'downloads' => DB::raw('downloads + 1'),
+                    'updated_at' => $now,
+                ]
             );
-
-            $dailyDownload->increment('downloads');
         }
 
         return Storage::disk(ProjectFile::getDisk())->download(

--- a/src/app/Http/Controllers/FileDownloadController.php
+++ b/src/app/Http/Controllers/FileDownloadController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Project;
 use App\Models\ProjectFile;
 use App\Models\ProjectType;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -17,7 +19,7 @@ class FileDownloadController extends Controller
      * @param  string  $file  File name (route key)
      * @return StreamedResponse
      */
-    public function download(ProjectType $projectType, Project $project, $version, $file)
+    public function download(Request $request, ProjectType $projectType, Project $project, $version, $file)
     {
 
         // Check if the project is deactivated
@@ -37,10 +39,31 @@ class FileDownloadController extends Controller
             abort(404, 'File not found');
         }
 
-        $version->increment('downloads');
-
         if (! Storage::exists($fileModel->path)) {
             abort(404, 'File not found');
+        }
+
+        $fingerprint = hash('sha256', implode('|', [
+            $request->ip(),
+            $request->userAgent() ?? 'unknown-agent',
+            $projectType->id,
+            $project->id,
+            $version->id,
+            $fileModel->id,
+        ]));
+
+        $dedupeKey = 'download_dedupe:'.$fingerprint;
+        $shouldCount = Cache::add($dedupeKey, true, now()->addHours(3));
+
+        if ($shouldCount) {
+            $version->increment('downloads');
+
+            $dailyDownload = $version->dailyDownloads()->firstOrCreate(
+                ['date' => today()->toDateString()],
+                ['downloads' => 0]
+            );
+
+            $dailyDownload->increment('downloads');
         }
 
         return Storage::disk(ProjectFile::getDisk())->download(

--- a/src/app/Livewire/Admin/Dashboard.php
+++ b/src/app/Livewire/Admin/Dashboard.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Models\Project;
 use App\Models\ProjectFile;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersion;
 use App\Models\User;
 use Livewire\Attributes\Layout;
@@ -19,7 +20,7 @@ class Dashboard extends Component
             'projects' => Project::count(),
             'versions' => ProjectVersion::count(),
             'files' => ProjectFile::count(),
-            'downloads' => ProjectVersion::sum('downloads'),
+            'downloads' => ProjectVersionDailyDownload::sum('downloads'),
             'admins' => User::where('role', 'admin')->count(),
         ];
 

--- a/src/app/Livewire/UserProfile.php
+++ b/src/app/Livewire/UserProfile.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\Project;
+use App\Models\ProjectVersion;
 use App\Models\Scopes\ProjectFullScope;
 use App\Models\User;
 use App\Services\ProjectService;
@@ -80,6 +81,22 @@ class UserProfile extends Component
             ->count();
     }
 
+    #[Computed]
+    public function aggregateDownloads()
+    {
+        $projectIds = Project::withoutGlobalScopes()
+            ->whereNull('project.deleted_at')
+            ->whereHas('memberships', function ($query) {
+                $query->where('membership.user_id', $this->user->id)
+                    ->where('membership.status', 'active');
+            })
+            ->pluck('project.id');
+
+        return ProjectVersion::query()
+            ->whereIn('project_id', $projectIds)
+            ->sum('downloads');
+    }
+
     // TODO: move it to service
     public function restoreProject($projectId)
     {
@@ -127,4 +144,3 @@ class UserProfile extends Component
             ->title($this->user->name);
     }
 }
-

--- a/src/app/Livewire/UserProfile.php
+++ b/src/app/Livewire/UserProfile.php
@@ -93,8 +93,9 @@ class UserProfile extends Component
             ->pluck('project.id');
 
         return ProjectVersion::query()
-            ->whereIn('project_id', $projectIds)
-            ->sum('downloads');
+            ->join('project_version_daily_download', 'project_version.id', '=', 'project_version_daily_download.project_version_id')
+            ->whereIn('project_version.project_id', $projectIds)
+            ->sum('project_version_daily_download.downloads');
     }
 
     // TODO: move it to service

--- a/src/app/Models/Project.php
+++ b/src/app/Models/Project.php
@@ -259,7 +259,12 @@ class Project extends Model
     #[Scope]
     protected function withStats(Builder $query): void
     {
-        $query->withSum('versions as downloads', 'downloads');
+        $query->addSelect([
+            'downloads' => ProjectVersionDailyDownload::query()
+                ->join('project_version', 'project_version.id', '=', 'project_version_daily_download.project_version_id')
+                ->selectRaw('COALESCE(SUM(project_version_daily_download.downloads), 0)')
+                ->whereColumn('project_version.project_id', 'project.id'),
+        ]);
         $query->withMax('versions as recent_release_date', 'release_date');
         // Add last update time as the greatest of the project updated_at and the maximum of all version release dates
         $query->addSelect([
@@ -430,7 +435,16 @@ class Project extends Model
     public function downloads(): Attribute
     {
         return Attribute::make(
-            get: fn () => $this->versions->sum('downloads')
+            get: function ($value, array $attributes) {
+                if (array_key_exists('downloads', $attributes)) {
+                    return (int) ($attributes['downloads'] ?? 0);
+                }
+
+                return (int) ProjectVersionDailyDownload::query()
+                    ->join('project_version', 'project_version.id', '=', 'project_version_daily_download.project_version_id')
+                    ->where('project_version.project_id', $this->id)
+                    ->sum('project_version_daily_download.downloads');
+            }
         );
     }
 

--- a/src/app/Models/ProjectVersion.php
+++ b/src/app/Models/ProjectVersion.php
@@ -31,13 +31,32 @@ class ProjectVersion extends Model
         'changelog',
         'release_type',
         'release_date',
-        'downloads',
     ];
 
     protected $casts = [
         'release_date' => 'date',
         'release_type' => ReleaseType::class,
     ];
+
+    /**
+     * Get total downloads from project_version_daily_download rows.
+     */
+    public function downloads(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value, array $attributes): int {
+                if (array_key_exists('downloads', $attributes)) {
+                    return (int) ($attributes['downloads'] ?? 0);
+                }
+
+                if ($this->relationLoaded('dailyDownloads')) {
+                    return (int) $this->dailyDownloads->sum('downloads');
+                }
+
+                return (int) $this->dailyDownloads()->sum('downloads');
+            }
+        );
+    }
 
     /**
      * Get the route key for the model.

--- a/src/app/Models/ProjectVersion.php
+++ b/src/app/Models/ProjectVersion.php
@@ -95,6 +95,14 @@ class ProjectVersion extends Model
     }
 
     /**
+     * Get daily download rows for this project version.
+     */
+    public function dailyDownloads(): HasMany
+    {
+        return $this->hasMany(ProjectVersionDailyDownload::class);
+    }
+
+    /**
      * Get all dependencies of this project version
      */
     public function dependencies(): HasMany

--- a/src/app/Models/ProjectVersionDailyDownload.php
+++ b/src/app/Models/ProjectVersionDailyDownload.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @mixin IdeHelperProjectVersionDailyDownload
+ */
+class ProjectVersionDailyDownload extends Model
+{
+    use HasFactory;
+
+    protected $table = 'project_version_daily_download';
+
+    protected $fillable = [
+        'project_version_id',
+        'date',
+        'downloads',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+
+    public function projectVersion(): BelongsTo
+    {
+        return $this->belongsTo(ProjectVersion::class);
+    }
+}

--- a/src/app/Services/ProjectVersionService.php
+++ b/src/app/Services/ProjectVersionService.php
@@ -387,7 +387,13 @@ class ProjectVersionService
                 }
             });
 
-        $query->orderBy($orderBy, $orderDirection);
+        if ($orderBy === 'downloads') {
+            $query
+                ->withSum('dailyDownloads as downloads', 'downloads')
+                ->orderBy('downloads', $orderDirection);
+        } else {
+            $query->orderBy($orderBy, $orderDirection);
+        }
 
         return $query->paginate($perPage);
     }

--- a/src/database/factories/ProjectVersionDailyDownloadFactory.php
+++ b/src/database/factories/ProjectVersionDailyDownloadFactory.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProjectVersion;
+use App\Models\ProjectVersionDailyDownload;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ProjectVersionDailyDownload>
+ */
+class ProjectVersionDailyDownloadFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = ProjectVersionDailyDownload::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'project_version_id' => ProjectVersion::factory(),
+            'date' => now()->toDateString(),
+            'downloads' => fake()->numberBetween(1, 75),
+        ];
+    }
+
+    /**
+     * Target a specific project version.
+     */
+    public function forVersion(ProjectVersion $projectVersion): static
+    {
+        return $this->state(fn () => [
+            'project_version_id' => $projectVersion->id,
+        ]);
+    }
+
+    /**
+     * Set an explicit date.
+     */
+    public function forDate(string $date): static
+    {
+        return $this->state(fn () => [
+            'date' => $date,
+        ]);
+    }
+
+    /**
+     * Set an explicit download total.
+     */
+    public function withDownloads(int $downloads): static
+    {
+        return $this->state(fn () => [
+            'downloads' => max(0, $downloads),
+        ]);
+    }
+
+    /**
+     * Lower traffic profile.
+     */
+    public function lowVolume(): static
+    {
+        return $this->state(fn () => [
+            'downloads' => fake()->numberBetween(1, 30),
+        ]);
+    }
+
+    /**
+     * Higher traffic profile.
+     */
+    public function highVolume(): static
+    {
+        return $this->state(fn () => [
+            'downloads' => fake()->numberBetween(250, 1500),
+        ]);
+    }
+}

--- a/src/database/factories/ProjectVersionFactory.php
+++ b/src/database/factories/ProjectVersionFactory.php
@@ -50,7 +50,6 @@ class ProjectVersionFactory extends Factory
             'changelog' => fake()->paragraphs(rand(1, 3), true),
             'release_type' => fake()->randomElement(['alpha', 'beta', 'prerelease', 'rc','release']),
             'release_date' => $relese_date,
-            'downloads' => fake()->numberBetween(0, 10000),
             'project_id' => Project::factory(),
             'created_at' => $relese_date,
             'updated_at' => $relese_date,

--- a/src/database/factories/ProjectVersionFactory.php
+++ b/src/database/factories/ProjectVersionFactory.php
@@ -4,8 +4,9 @@ namespace Database\Factories;
 
 use App\Models\Project;
 use App\Models\ProjectVersion;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersionTag;
-use App\Models\ProjectType;
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -13,6 +14,18 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class ProjectVersionFactory extends Factory
 {
+    protected bool $generateDailyDownloads = true;
+
+    protected int $dailyDownloadsMaxDays = 180;
+
+    protected int $dailyDownloadsMin = 2;
+
+    protected int $dailyDownloadsMax = 120;
+
+    protected bool $dailyDownloadsDeterministic = false;
+
+    protected float $dailyDownloadsGrowthExponent = 1.4;
+
     /**
      * Configure the model factory.
      */
@@ -32,6 +45,10 @@ class ProjectVersionFactory extends Factory
             // Assign some random subtags from the already assigned tags
             $subTags = ProjectVersionTag::whereIn('parent_id', $tags->pluck('id'))->inRandomOrder()->take(rand(0, 2))->get();
             $projectVersion->tags()->attach($subTags);
+
+            if ($this->generateDailyDownloads) {
+                $this->generateTrendingDailyDownloads($projectVersion);
+            }
         });
 
     }
@@ -43,17 +60,78 @@ class ProjectVersionFactory extends Factory
      */
     public function definition(): array
     {
-        $relese_date = fake()->dateTimeBetween('-1 years', 'now');
+        $releaseDate = fake()->dateTimeBetween('-1 years', 'now');
+
         return [
             'name' => fake()->words(rand(1, 3), true),
             'version' => fake()->unique()->numerify('#.#.#'),
             'changelog' => fake()->paragraphs(rand(1, 3), true),
-            'release_type' => fake()->randomElement(['alpha', 'beta', 'prerelease', 'rc','release']),
-            'release_date' => $relese_date,
+            'release_type' => fake()->randomElement(['alpha', 'beta', 'prerelease', 'rc', 'release']),
+            'release_date' => $releaseDate,
             'project_id' => Project::factory(),
-            'created_at' => $relese_date,
-            'updated_at' => $relese_date,
+            'created_at' => $releaseDate,
+            'updated_at' => $releaseDate,
         ];
+    }
+
+    /**
+     * Disable automatic daily download history generation.
+     */
+    public function withoutDailyDownloads(): static
+    {
+        return $this
+            ->withDailyDownloadConfiguration([
+                'generateDailyDownloads' => false,
+            ])
+            ->afterCreating(function (ProjectVersion $projectVersion) {
+                $projectVersion->dailyDownloads()->delete();
+            });
+    }
+
+    /**
+     * Generate stronger recent-growth traffic.
+     */
+    public function highIntensityDailyDownloads(): static
+    {
+        return $this->withDailyDownloadConfiguration([
+            'dailyDownloadsMin' => 20,
+            'dailyDownloadsMax' => 300,
+            'dailyDownloadsGrowthExponent' => 1.7,
+        ]);
+    }
+
+    /**
+     * Restrict generated history to a max day window.
+     */
+    public function dailyDownloadWindow(int $maxDays): static
+    {
+        return $this->withDailyDownloadConfiguration([
+            'dailyDownloadsMaxDays' => max(1, $maxDays),
+        ]);
+    }
+
+    /**
+     * Use deterministic generation for stable test assertions.
+     */
+    public function deterministicDailyDownloads(): static
+    {
+        return $this->withDailyDownloadConfiguration([
+            'dailyDownloadsDeterministic' => true,
+        ]);
+    }
+
+    /**
+     * Override the daily download min/max range.
+     */
+    public function dailyDownloadRange(int $min, int $max): static
+    {
+        $normalizedMin = max(0, min($min, $max));
+        $normalizedMax = max($normalizedMin, max($min, $max));
+
+        return $this->withDailyDownloadConfiguration([
+            'dailyDownloadsMin' => $normalizedMin,
+            'dailyDownloadsMax' => $normalizedMax,
+        ]);
     }
 
     /**
@@ -94,5 +172,69 @@ class ProjectVersionFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'release_type' => 'release',
         ]);
+    }
+
+    /**
+     * @param  array<string, bool|int|float>  $overrides
+     */
+    protected function withDailyDownloadConfiguration(array $overrides): static
+    {
+        $factory = clone $this;
+
+        foreach ($overrides as $property => $value) {
+            $factory->{$property} = $value;
+        }
+
+        return $factory;
+    }
+
+    protected function generateTrendingDailyDownloads(ProjectVersion $projectVersion): void
+    {
+        $releaseDate = CarbonImmutable::parse($projectVersion->release_date ?? $projectVersion->created_at)->startOfDay();
+        $today = CarbonImmutable::today();
+
+        if ($releaseDate->greaterThan($today)) {
+            $releaseDate = $today;
+        }
+
+        $totalDaysInclusive = $releaseDate->diffInDays($today) + 1;
+        $windowDays = min($totalDaysInclusive, $this->dailyDownloadsMaxDays);
+        $historyStart = $today->subDays($windowDays - 1);
+
+        if ($releaseDate->greaterThan($historyStart)) {
+            $historyStart = $releaseDate;
+        }
+
+        $historyDays = (int) $historyStart->diffInDays($today);
+        $historySpan = max(1, $historyDays);
+        $rows = [];
+
+        for ($offset = 0; $offset <= $historyDays; $offset++) {
+            $date = $historyStart->addDays($offset);
+            $progress = $historyDays <= 0 ? 1.0 : $offset / $historySpan;
+            $trendProgress = $progress ** $this->dailyDownloadsGrowthExponent;
+
+            $base = $this->dailyDownloadsMin + (($this->dailyDownloadsMax - $this->dailyDownloadsMin) * $trendProgress);
+            $variance = max(1, (int) round($base * 0.2));
+
+            if ($this->dailyDownloadsDeterministic) {
+                $seed = crc32($projectVersion->id.'|'.$date->toDateString());
+                $noise = ($seed % (($variance * 2) + 1)) - $variance;
+            } else {
+                $noise = random_int(-$variance, $variance);
+            }
+
+            $downloads = max(0, (int) round($base + $noise));
+
+            $rows[] = [
+                'project_version_id' => $projectVersion->id,
+                'date' => $date->toDateString(),
+                'downloads' => $downloads,
+                'created_at' => $projectVersion->created_at,
+                'updated_at' => $projectVersion->updated_at,
+            ];
+        }
+
+        ProjectVersionDailyDownload::query()->insert($rows);
     }
 }

--- a/src/database/migrations/2026_02_24_180000_create_project_version_daily_download_table.php
+++ b/src/database/migrations/2026_02_24_180000_create_project_version_daily_download_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_version_daily_download', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_version_id')->constrained('project_version')->cascadeOnDelete();
+            $table->date('date');
+            $table->unsignedInteger('downloads')->default(0);
+            $table->timestamps();
+
+            $table->unique(['project_version_id', 'date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_version_daily_download');
+    }
+};

--- a/src/database/migrations/2026_02_24_181000_backfill_project_version_downloads_to_daily_downloads.php
+++ b/src/database/migrations/2026_02_24_181000_backfill_project_version_downloads_to_daily_downloads.php
@@ -1,0 +1,100 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $today = now()->startOfDay();
+        $driver = DB::getDriverName();
+
+        DB::table('project_version')
+            ->select(['id', 'downloads', 'created_at'])
+            ->where('downloads', '>', 0)
+            ->orderBy('id')
+            ->chunkById(250, function ($versions) use ($today, $driver): void {
+                $rows = [];
+                $now = now();
+
+                foreach ($versions as $version) {
+                    $downloads = (int) $version->downloads;
+
+                    if ($downloads <= 0) {
+                        continue;
+                    }
+
+                    $startDate = Carbon::parse($version->created_at)->startOfDay();
+                    if ($startDate->greaterThan($today)) {
+                        $startDate = $today->copy();
+                    }
+
+                    $days = $startDate->diffInDays($today) + 1;
+                    if ($days <= 0) {
+                        continue;
+                    }
+
+                    $base = intdiv($downloads, $days);
+                    $remainder = $downloads % $days;
+
+                    for ($i = 0; $i < $days; $i++) {
+                        $allocated = $base + ($i < $remainder ? 1 : 0);
+
+                        if ($allocated === 0) {
+                            continue;
+                        }
+
+                        $rows[] = [
+                            'project_version_id' => $version->id,
+                            'date' => $startDate->copy()->addDays($i)->toDateString(),
+                            'downloads' => $allocated,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+                }
+
+                if (empty($rows)) {
+                    return;
+                }
+
+                if (in_array($driver, ['mysql', 'mariadb'], true)) {
+                    DB::table('project_version_daily_download')->upsert(
+                        $rows,
+                        ['project_version_id', 'date'],
+                        [
+                            'downloads' => DB::raw('downloads + VALUES(downloads)'),
+                            'updated_at' => DB::raw('VALUES(updated_at)'),
+                        ]
+                    );
+
+                    return;
+                }
+
+                foreach ($rows as $row) {
+                    $updated = DB::table('project_version_daily_download')
+                        ->where('project_version_id', $row['project_version_id'])
+                        ->where('date', $row['date'])
+                        ->increment('downloads', $row['downloads'], ['updated_at' => $row['updated_at']]);
+
+                    if (! $updated) {
+                        DB::table('project_version_daily_download')->insert($row);
+                    }
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No-op: impossible to safely distinguish historical backfilled rows from real daily rows.
+    }
+};
+

--- a/src/database/migrations/2026_02_24_182000_drop_downloads_from_project_version_table.php
+++ b/src/database/migrations/2026_02_24_182000_drop_downloads_from_project_version_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('project_version', 'downloads')) {
+            Schema::table('project_version', function (Blueprint $table) {
+                $table->dropColumn('downloads');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasColumn('project_version', 'downloads')) {
+            Schema::table('project_version', function (Blueprint $table) {
+                $table->unsignedInteger('downloads')->default(0)->after('release_date');
+            });
+        }
+    }
+};
+

--- a/src/resources/views/livewire/user-profile.blade.php
+++ b/src/resources/views/livewire/user-profile.blade.php
@@ -25,6 +25,8 @@
                                 label="{{ $this->ownedProjectsCount }} {{ Str::plural('project', $this->ownedProjectsCount) }} owned" />
                             <x-icon name="lucide-users"
                                 label="{{ $this->contributionsCount }} {{ Str::plural('contribution', $this->contributionsCount) }}" />
+                            <x-icon name="lucide-download"
+                                label="{{ number_format($this->aggregateDownloads) }} {{ Str::plural('download', $this->aggregateDownloads) }}" />
                         </div>
                     </x-slot:subtitle>
                 </x-avatar>

--- a/src/tests/Feature/Api/ProjectTest.php
+++ b/src/tests/Feature/Api/ProjectTest.php
@@ -7,6 +7,7 @@ use App\Models\Project;
 use App\Models\ProjectTag;
 use App\Models\ProjectType;
 use App\Models\ProjectVersion;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersionTag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -295,6 +296,10 @@ class ProjectTest extends TestCase
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionLow->id,
+            'date' => now()->toDateString(),
             'downloads' => 10,
         ]);
 
@@ -307,6 +312,10 @@ class ProjectTest extends TestCase
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionHigh->id,
+            'date' => now()->toDateString(),
             'downloads' => 1000,
         ]);
 

--- a/src/tests/Feature/Api/ProjectTest.php
+++ b/src/tests/Feature/Api/ProjectTest.php
@@ -297,11 +297,11 @@ class ProjectTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionLow->id,
-            'date' => now()->toDateString(),
-            'downloads' => 10,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionLow)
+            ->forDate(now()->toDateString())
+            ->withDownloads(10)
+            ->create();
 
         $projectHigh = Project::factory()->owner($user)->create([
             'project_type_id' => $this->projectType->id,
@@ -313,11 +313,11 @@ class ProjectTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionHigh->id,
-            'date' => now()->toDateString(),
-            'downloads' => 1000,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionHigh)
+            ->forDate(now()->toDateString())
+            ->withDownloads(1000)
+            ->create();
 
         $response = $this->getJson(route('api.v1.projects', ['order_by' => 'downloads', 'order_direction' => 'desc', 'project_type' => $this->projectType->value]));
 

--- a/src/tests/Feature/Api/ProjectVersionTest.php
+++ b/src/tests/Feature/Api/ProjectVersionTest.php
@@ -290,11 +290,11 @@ class ProjectVersionTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionLow->id,
-            'date' => now()->toDateString(),
-            'downloads' => 10,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionLow)
+            ->forDate(now()->toDateString())
+            ->withDownloads(10)
+            ->create();
 
         $versionHigh = $project->versions()->create([
             'name' => 'Version 2.0.0',
@@ -302,11 +302,11 @@ class ProjectVersionTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionHigh->id,
-            'date' => now()->toDateString(),
-            'downloads' => 1000,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionHigh)
+            ->forDate(now()->toDateString())
+            ->withDownloads(1000)
+            ->create();
 
         $response = $this->getJson(route('api.v1.project_versions', [
             'slug' => $project->slug,

--- a/src/tests/Feature/Api/ProjectVersionTest.php
+++ b/src/tests/Feature/Api/ProjectVersionTest.php
@@ -7,6 +7,7 @@ use App\Models\ProjectFile;
 use App\Models\ProjectQuota;
 use App\Models\ProjectType;
 use App\Models\ProjectVersion;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersionDependency;
 use App\Models\ProjectVersionTag;
 use App\Models\User;
@@ -288,6 +289,10 @@ class ProjectVersionTest extends TestCase
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionLow->id,
+            'date' => now()->toDateString(),
             'downloads' => 10,
         ]);
 
@@ -296,6 +301,10 @@ class ProjectVersionTest extends TestCase
             'version' => '2.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionHigh->id,
+            'date' => now()->toDateString(),
             'downloads' => 1000,
         ]);
 

--- a/src/tests/Feature/Project/Http/Controllers/FileDownloadControllerTest.php
+++ b/src/tests/Feature/Project/Http/Controllers/FileDownloadControllerTest.php
@@ -34,7 +34,7 @@ class FileDownloadControllerTest extends TestCase
         $this->project = Project::factory()->owner($this->user)->create([
             'project_type_id' => $this->projectType->id,
         ]);
-        $this->version = ProjectVersion::factory()->create([
+        $this->version = ProjectVersion::factory()->withoutDailyDownloads()->create([
             'project_id' => $this->project->id,
             'version' => '1.0.0',
         ]);

--- a/src/tests/Feature/Project/Http/Controllers/FileDownloadControllerTest.php
+++ b/src/tests/Feature/Project/Http/Controllers/FileDownloadControllerTest.php
@@ -6,8 +6,10 @@ use App\Models\Project;
 use App\Models\ProjectFile;
 use App\Models\ProjectType;
 use App\Models\ProjectVersion;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -25,6 +27,7 @@ class FileDownloadControllerTest extends TestCase
     {
         parent::setUp();
         Storage::fake('public');
+        Cache::flush();
 
         $this->projectType = ProjectType::factory()->create();
         $this->user = User::factory()->create();
@@ -83,6 +86,70 @@ class FileDownloadControllerTest extends TestCase
 
         $this->version->refresh();
         $this->assertEquals($initialDownloads + 1, $this->version->downloads);
+    }
+
+    #[Test]
+    public function test_download_is_deduplicated_for_three_hours_but_still_served()
+    {
+        $file = $this->version->files()->create([
+            'name' => 'dedupe.zip',
+            'path' => 'project-files/dedupe.zip',
+            'size' => 512,
+        ]);
+
+        $initialDownloads = $this->version->downloads;
+
+        Storage::disk(ProjectFile::getDisk())->put($file->path, 'content');
+
+        $route = route('file.download', [
+            'projectType' => $this->projectType,
+            'project' => $this->project,
+            'version' => $this->version->version,
+            'file' => $file->name,
+        ]);
+
+        $responseOne = $this->withHeader('User-Agent', 'Hub01-Test-Agent')->get($route);
+        $responseTwo = $this->withHeader('User-Agent', 'Hub01-Test-Agent')->get($route);
+
+        $responseOne->assertOk()->assertDownload($file->name);
+        $responseTwo->assertOk()->assertDownload($file->name);
+
+        $this->version->refresh();
+        $this->assertEquals($initialDownloads + 1, $this->version->downloads);
+    }
+
+    #[Test]
+    public function test_counted_download_increments_daily_download_row()
+    {
+        $file = $this->version->files()->create([
+            'name' => 'daily.zip',
+            'path' => 'project-files/daily.zip',
+            'size' => 128,
+        ]);
+
+        Storage::disk(ProjectFile::getDisk())->put($file->path, 'content');
+
+        $this->withHeader('User-Agent', 'Hub01-Daily-Agent')
+            ->get(route('file.download', [
+                'projectType' => $this->projectType,
+                'project' => $this->project,
+                'version' => $this->version->version,
+                'file' => $file->name,
+            ]))
+            ->assertOk();
+
+        $this->assertDatabaseHas('project_version_daily_download', [
+            'project_version_id' => $this->version->id,
+            'date' => today()->toDateString(),
+            'downloads' => 1,
+        ]);
+
+        $this->assertEquals(
+            1,
+            ProjectVersionDailyDownload::where('project_version_id', $this->version->id)
+                ->whereDate('date', today())
+                ->value('downloads')
+        );
     }
 
     #[Test]
@@ -182,6 +249,8 @@ class FileDownloadControllerTest extends TestCase
     #[Test]
     public function test_cannot_download_nonexistent_file()
     {
+        $initialDownloads = $this->version->downloads;
+
         $this->get(route('file.download', [
             'projectType' => $this->projectType,
             'project' => $this->project,
@@ -189,6 +258,13 @@ class FileDownloadControllerTest extends TestCase
             'file' => 'nonexistent.zip',
         ]))
             ->assertNotFound();
+
+        $this->version->refresh();
+        $this->assertEquals($initialDownloads, $this->version->downloads);
+        $this->assertDatabaseMissing('project_version_daily_download', [
+            'project_version_id' => $this->version->id,
+            'date' => today()->toDateString(),
+        ]);
     }
 
     #[Test]
@@ -200,6 +276,8 @@ class FileDownloadControllerTest extends TestCase
             'size' => 1024,
         ]);
 
+        $initialDownloads = $this->version->downloads;
+
         // Don't put file in storage
 
         $this->get(route('file.download', [
@@ -209,6 +287,13 @@ class FileDownloadControllerTest extends TestCase
             'file' => $file->name,
         ]))
             ->assertNotFound();
+
+        $this->version->refresh();
+        $this->assertEquals($initialDownloads, $this->version->downloads);
+        $this->assertDatabaseMissing('project_version_daily_download', [
+            'project_version_id' => $this->version->id,
+            'date' => today()->toDateString(),
+        ]);
     }
 
     #[Test]

--- a/src/tests/Feature/Project/Livewire/ProjectSearchTest.php
+++ b/src/tests/Feature/Project/Livewire/ProjectSearchTest.php
@@ -6,6 +6,7 @@ use App\Livewire\ProjectSearch;
 use App\Models\Project;
 use App\Models\ProjectTag;
 use App\Models\ProjectType;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersionTag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -153,6 +154,10 @@ class ProjectSearchTest extends TestCase
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionLow->id,
+            'date' => now()->toDateString(),
             'downloads' => 10,
         ]);
 
@@ -165,6 +170,10 @@ class ProjectSearchTest extends TestCase
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionHigh->id,
+            'date' => now()->toDateString(),
             'downloads' => 1000,
         ]);
 

--- a/src/tests/Feature/Project/Livewire/ProjectSearchTest.php
+++ b/src/tests/Feature/Project/Livewire/ProjectSearchTest.php
@@ -155,11 +155,11 @@ class ProjectSearchTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionLow->id,
-            'date' => now()->toDateString(),
-            'downloads' => 10,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionLow)
+            ->forDate(now()->toDateString())
+            ->withDownloads(10)
+            ->create();
 
         $projectHigh = Project::factory()->owner($user)->create([
             'project_type_id' => $this->projectType->id,
@@ -171,11 +171,11 @@ class ProjectSearchTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionHigh->id,
-            'date' => now()->toDateString(),
-            'downloads' => 1000,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionHigh)
+            ->forDate(now()->toDateString())
+            ->withDownloads(1000)
+            ->create();
 
         $component = Livewire::test(ProjectSearch::class, ['projectType' => $this->projectType])
             ->set('orderBy', 'downloads')

--- a/src/tests/Feature/User/Livewire/UserProfileTest.php
+++ b/src/tests/Feature/User/Livewire/UserProfileTest.php
@@ -140,11 +140,11 @@ class UserProfileTest extends TestCase
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $ownedProject->versions()->first()->id,
-            'date' => now()->toDateString(),
-            'downloads' => 12,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($ownedProject->versions()->first())
+            ->forDate(now()->toDateString())
+            ->withDownloads(12)
+            ->create();
 
         $contributorProject = Project::factory()->create();
         Membership::factory()->create([
@@ -159,11 +159,11 @@ class UserProfileTest extends TestCase
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $contributorProject->versions()->first()->id,
-            'date' => now()->toDateString(),
-            'downloads' => 7,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($contributorProject->versions()->first())
+            ->forDate(now()->toDateString())
+            ->withDownloads(7)
+            ->create();
 
         $inactiveContributorProject = Project::factory()->create();
         Membership::factory()->create([
@@ -178,11 +178,11 @@ class UserProfileTest extends TestCase
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $inactiveContributorProject->versions()->first()->id,
-            'date' => now()->toDateString(),
-            'downloads' => 100,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($inactiveContributorProject->versions()->first())
+            ->forDate(now()->toDateString())
+            ->withDownloads(100)
+            ->create();
 
         Livewire::actingAs($user)
             ->test(UserProfile::class, ['user' => $user])

--- a/src/tests/Feature/User/Livewire/UserProfileTest.php
+++ b/src/tests/Feature/User/Livewire/UserProfileTest.php
@@ -20,7 +20,7 @@ class UserProfileTest extends TestCase
     public function test_user_profile_component_renders()
     {
         $user = User::factory()->create();
-        
+
         Livewire::actingAs($user)
             ->test(UserProfile::class, ['user' => $user])
             ->assertOk()
@@ -31,11 +31,11 @@ class UserProfileTest extends TestCase
     public function test_active_projects_computed_property()
     {
         $user = User::factory()->create();
-        
+
         // Create 2 active projects owned by user
         $project1 = Project::factory()->owner($user)->create(['created_at' => now()->subDay()]);
         $project2 = Project::factory()->owner($user)->create(['created_at' => now()]);
-        
+
         // Create 1 project NOT owned by user
         Project::factory()->create();
 
@@ -49,11 +49,11 @@ class UserProfileTest extends TestCase
     {
         $user = User::factory()->create();
         $otherUser = User::factory()->create();
-        
+
         // Create deleted project owned by user
         $project1 = Project::factory()->owner($user)->create();
         $project1->delete();
-        
+
         // Create active project
         Project::factory()->owner($user)->create();
 
@@ -72,11 +72,11 @@ class UserProfileTest extends TestCase
     public function test_owned_projects_count()
     {
         $user = User::factory()->create();
-        
+
         // 2 Owned projects
         Project::factory()->owner($user)->create();
         Project::factory()->owner($user)->create();
-        
+
         // 1 Contribution (not owned)
         $project3 = Project::factory()->create();
         $membership = new Membership([
@@ -97,10 +97,10 @@ class UserProfileTest extends TestCase
     public function test_contributions_count()
     {
         $user = User::factory()->create();
-        
+
         // 1 Owned project
         Project::factory()->owner($user)->create();
-        
+
         // 2 Contributions (not owned)
         $project2 = Project::factory()->create();
         $membership = new Membership([
@@ -111,7 +111,7 @@ class UserProfileTest extends TestCase
         $membership->user()->associate($user);
         $membership->project()->associate($project2);
         $membership->save();
-        
+
         $project3 = Project::factory()->create();
         $membership = new Membership([
             'role' => 'viewer',
@@ -128,6 +128,56 @@ class UserProfileTest extends TestCase
     }
 
     #[Test]
+    public function test_aggregate_downloads_includes_owned_and_active_contributor_projects()
+    {
+        $user = User::factory()->create();
+
+        $ownedProject = Project::factory()->owner($user)->create();
+        $ownedProject->versions()->create([
+            'name' => 'Owned v1',
+            'version' => '1.0.0',
+            'release_type' => 'release',
+            'release_date' => now()->toDateString(),
+            'downloads' => 12,
+        ]);
+
+        $contributorProject = Project::factory()->create();
+        Membership::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => $contributorProject->id,
+            'primary' => false,
+            'status' => 'active',
+        ]);
+        $contributorProject->versions()->create([
+            'name' => 'Contributor v1',
+            'version' => '2.0.0',
+            'release_type' => 'release',
+            'release_date' => now()->toDateString(),
+            'downloads' => 7,
+        ]);
+
+        $inactiveContributorProject = Project::factory()->create();
+        Membership::factory()->create([
+            'user_id' => $user->id,
+            'project_id' => $inactiveContributorProject->id,
+            'primary' => false,
+            'status' => 'pending',
+        ]);
+        $inactiveContributorProject->versions()->create([
+            'name' => 'Pending v1',
+            'version' => '3.0.0',
+            'release_type' => 'release',
+            'release_date' => now()->toDateString(),
+            'downloads' => 100,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(UserProfile::class, ['user' => $user])
+            ->assertSet('aggregateDownloads', 19)
+            ->assertSee('19 downloads');
+    }
+
+    #[Test]
     public function test_restore_project()
     {
         $user = User::factory()->create();
@@ -135,7 +185,7 @@ class UserProfileTest extends TestCase
         $project->delete();
 
         $this->assertTrue($project->fresh()->trashed());
-        
+
         Livewire::actingAs($user)
             ->test(UserProfile::class, ['user' => $user])
             ->call('restoreProject', $project->id)

--- a/src/tests/Feature/User/Livewire/UserProfileTest.php
+++ b/src/tests/Feature/User/Livewire/UserProfileTest.php
@@ -6,6 +6,7 @@ use App\Livewire\UserProfile;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Membership;
+use App\Models\ProjectVersionDailyDownload;
 use App\Services\ProjectService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
@@ -138,6 +139,10 @@ class UserProfileTest extends TestCase
             'version' => '1.0.0',
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $ownedProject->versions()->first()->id,
+            'date' => now()->toDateString(),
             'downloads' => 12,
         ]);
 
@@ -153,6 +158,10 @@ class UserProfileTest extends TestCase
             'version' => '2.0.0',
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $contributorProject->versions()->first()->id,
+            'date' => now()->toDateString(),
             'downloads' => 7,
         ]);
 
@@ -168,6 +177,10 @@ class UserProfileTest extends TestCase
             'version' => '3.0.0',
             'release_type' => 'release',
             'release_date' => now()->toDateString(),
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $inactiveContributorProject->versions()->first()->id,
+            'date' => now()->toDateString(),
             'downloads' => 100,
         ]);
 

--- a/src/tests/Unit/ProjectServiceTest.php
+++ b/src/tests/Unit/ProjectServiceTest.php
@@ -95,11 +95,11 @@ class ProjectServiceTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionLow->id,
-            'date' => now()->toDateString(),
-            'downloads' => 10,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionLow)
+            ->forDate(now()->toDateString())
+            ->withDownloads(10)
+            ->create();
 
         $projectHigh = Project::factory()->owner($this->user)->create(['project_type_id' => $this->projectType->id]);
         $versionHigh = $projectHigh->versions()->create([
@@ -108,11 +108,11 @@ class ProjectServiceTest extends TestCase
             'release_date' => now(),
             'release_type' => 'release',
         ]);
-        ProjectVersionDailyDownload::create([
-            'project_version_id' => $versionHigh->id,
-            'date' => now()->toDateString(),
-            'downloads' => 1000,
-        ]);
+        ProjectVersionDailyDownload::factory()
+            ->forVersion($versionHigh)
+            ->forDate(now()->toDateString())
+            ->withDownloads(1000)
+            ->create();
 
         $results = $this->projectService->searchProjects(
             projectType: $this->projectType,

--- a/src/tests/Unit/ProjectServiceTest.php
+++ b/src/tests/Unit/ProjectServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\Project;
 use App\Models\ProjectTag;
 use App\Models\ProjectTagGroup;
 use App\Models\ProjectType;
+use App\Models\ProjectVersionDailyDownload;
 use App\Models\ProjectVersionTag;
 use App\Models\ProjectVersionTagGroup;
 use App\Models\User;
@@ -88,20 +89,28 @@ class ProjectServiceTest extends TestCase
     public function test_order_projects_by_downloads()
     {
         $projectLow = Project::factory()->owner($this->user)->create(['project_type_id' => $this->projectType->id]);
-        $projectLow->versions()->create([
+        $versionLow = $projectLow->versions()->create([
             'name' => 'Low Downloads Version',
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionLow->id,
+            'date' => now()->toDateString(),
             'downloads' => 10,
         ]);
 
         $projectHigh = Project::factory()->owner($this->user)->create(['project_type_id' => $this->projectType->id]);
-        $projectHigh->versions()->create([
+        $versionHigh = $projectHigh->versions()->create([
             'name' => 'High Downloads Version',
             'version' => '1.0.0',
             'release_date' => now(),
             'release_type' => 'release',
+        ]);
+        ProjectVersionDailyDownload::create([
+            'project_version_id' => $versionHigh->id,
+            'date' => now()->toDateString(),
             'downloads' => 1000,
         ]);
 


### PR DESCRIPTION
Summary

This pull request improves download analytics accuracy and scalability by introducing time-window deduplication for download counting and moving persisted totals to a daily aggregation model.

What changed

Added download deduplication so repeated requests from the same client fingerprint within a 3-hour window are served normally but counted only once.
Introduced per-version daily download records and wired them into read/write paths for analytics and reporting.
Updated aggregate download calculations used in user and admin-facing statistics to use daily data.
Refactored query and service logic to read totals from daily aggregates rather than a single legacy counter field.
Added migrations to backfill historical totals into daily rows, then remove the legacy downloads column.
Updated factories and tests to align with the new storage and aggregation behavior.

Breaking change
The legacy project version downloads column is removed.
Any consumer that previously read that field must now use aggregated totals from daily download records.

Why
Prevents inflated counts caused by rapid repeated downloads.
Provides better historical granularity for reporting.
Improves long-term maintainability by centralizing analytics on daily aggregates.

Validation
Feature and unit test coverage was updated for download counting, API responses, search sorting/aggregation behavior, and user profile statistics.