### PR TITLE
feat(ui): improve project show page responsiveness

### DIFF
--- a/src/resources/views/livewire/project-show.blade.php
+++ b/src/resources/views/livewire/project-show.blade.php
@@ -1,115 +1,144 @@
 <div>
     <livewire:report-abuse />
 
-    <!-- Back Button and Actions -->
-    <div class="mb-6 flex justify-between items-center flex-wrap gap-4">
-        <x-button link="{{ route('project-search', ['projectType' => $project->projectType]) }}" icon="arrow-left"
-            label="Back to Projects" class="btn-ghost" no-wire-navigate />
-        <div class="flex flex-col lg:flex-row gap-2">
+    {{-- Status Alerts --}}
+    @if ($project->isPending())
+        <x-alert title="This project is under review"
+            description="This project is currently pending admin approval. Only the owner can see it, and it cannot be edited until the review is complete."
+            icon="clock" class="mb-4 alert-warning" />
+    @endif
+
+    @if ($project->isDraft())
+        <x-alert title="This project is a draft"
+            description="This project is currently a draft. Only the owner can see it, you can submit it for review in the project settings."
+            icon="clock" class="mb-4 alert-info" />
+    @endif
+
+    @if ($project->isRejected())
+        <x-alert title="This project was rejected"
+            description="This project was rejected by an admin. {{ $project->rejection_reason ?: 'Please contact an administrator for more information.' }}"
+            icon="x-circle" class="mb-4 alert-error" />
+    @endif
+
+    @if ($project->status === 'inactive')
+        <x-alert title="This project is currently inactive"
+            description="This project has been marked as inactive by its maintainers. It may not be actively maintained or supported."
+            icon="triangle-alert" class="mb-4 alert-warning" />
+    @endif
+
+    {{-- Top Action Bar --}}
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+        {{-- Back button --}}
+        <x-button link="{{ route('project-search', ['projectType' => $project->projectType]) }}"
+            icon="arrow-left"
+            label="Back to Projects"
+            class="btn-ghost btn-sm"
+            no-wire-navigate />
+
+        {{-- Action buttons --}}
+        <div class="flex items-center gap-2">
             @auth
                 @can('uploadVersion', $project)
                     <x-button
                         link="{{ route('project.version.create', ['projectType' => $project->projectType, 'project' => $this->project]) }}"
-                        icon="upload" label="Upload Version" class="btn-success" no-wire-navigate />
+                        icon="upload"
+                        label="Upload Version"
+                        class="btn-success btn-sm hidden sm:inline-flex"
+                        no-wire-navigate />
+                    {{-- Mobile: icon-only upload --}}
+                    <x-button
+                        link="{{ route('project.version.create', ['projectType' => $project->projectType, 'project' => $this->project]) }}"
+                        icon="upload"
+                        class="btn-success btn-sm btn-square sm:hidden"
+                        no-wire-navigate />
                 @endcan
 
                 @can('update', $project)
                     <x-button
                         link="{{ route('project.edit', ['projectType' => $project->projectType, 'project' => $project]) }}"
-                        icon="pencil" label="Edit Project" class="btn-primary" no-wire-navigate />
+                        icon="pencil"
+                        label="Edit Project"
+                        class="btn-primary btn-sm hidden sm:inline-flex"
+                        no-wire-navigate />
+                    {{-- Mobile: icon-only edit --}}
+                    <x-button
+                        link="{{ route('project.edit', ['projectType' => $project->projectType, 'project' => $project]) }}"
+                        icon="pencil"
+                        class="btn-primary btn-sm btn-square sm:hidden"
+                        no-wire-navigate />
                 @endcan
+
+                {{-- Favorite --}}
                 <x-button
                     icon="heart"
-                    class="btn-ghost [&_svg]:w-6 [&_svg]:h-6 {{ (bool) ($project->is_favorited ?? false) ? 'text-secondary' : '' }}"
+                    class="btn-ghost btn-sm btn-square [&_svg]:w-5 [&_svg]:h-5 {{ (bool) ($project->is_favorited ?? false) ? 'text-secondary' : '' }}"
                     wire:click="toggleFavorite({{ $project->id }})"
                     title="{{ (bool) ($project->is_favorited ?? false) ? 'Remove from favorites' : 'Add to favorites' }}"
                 />
+
+                {{-- Bookmark --}}
                 <x-button
                     icon="bookmark"
-                    class="btn-ghost [&_svg]:w-6 [&_svg]:h-6 {{ $this->isInUserCollection ? 'text-info' : '' }}"
+                    class="btn-ghost btn-sm btn-square [&_svg]:w-5 [&_svg]:h-5 {{ $this->isInUserCollection ? 'text-info' : '' }}"
                     wire:click="openAddToCollectionModal({{ $project->id }})"
                     title="Add to collection"
                 />
             @endauth
+
+            {{-- More menu --}}
             <x-dropdown right>
                 <x-slot:trigger>
-                    <x-button icon="ellipsis" class="btn-ghost" />
+                    <x-button icon="ellipsis" class="btn-ghost btn-sm btn-square" />
                 </x-slot:trigger>
-
                 <x-menu-item title="Report" class="text-error" icon="flag"
                     @click="$dispatch('open-report-modal', { itemId: {{ $project->id }}, itemType: 'App\\\\Models\\\\Project', itemName: '{{ addslashes($project->name) }}' })" />
             </x-dropdown>
         </div>
     </div>
 
-    {{-- Pending Approval Notice --}}
-    @if ($project->isPending())
-        <x-alert title="This project is under review"
-            description="This project is currently pending admin approval. Only the owner can see it, and it cannot be edited until the review is complete."
-            icon="clock" class="mb-6 alert-warning" />
-    @endif
+    {{-- Main Layout: stacked on mobile, 2-col on lg --}}
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-6">
 
-    {{-- Draft Project Notice --}}
-    @if ($project->isDraft())
-        <x-alert title="This project is a draft"
-            description="This project is currently a draft. Only the owner can see it, you can submit it for review in the project settings."
-            icon="clock" class="mb-6 alert-info" />
-    @endif
+        {{-- Left Column --}}
+        <div class="lg:col-span-8 flex flex-col gap-4">
 
-    {{-- Rejected Project Notice --}}
-    @if ($project->isRejected())
-        <x-alert title="This project was rejected"
-            description="This project was rejected by an admin. {{ $project->rejection_reason ?: 'Please contact an administrator for more information.' }}"
-            icon="x-circle" class="mb-6 alert-error" />
-    @endif
+            {{-- Project Card --}}
+            <x-project-card :project="$project" />
 
-    {{-- Inactive Project Notice --}}
-    @if ($project->status === 'inactive')
-        <x-alert title="This project is currently inactive"
-            description="This project has been marked as inactive by its maintainers. It may not be actively maintained or supported."
-            icon="triangle-alert" class="mb-6 alert-warning" />
-    @endif
-
-    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        <!-- Left Column - Main Content -->
-        <div class="lg:col-span-8">
-            <!-- Project Card -->
-            <div class="mb-6">
-                <x-project-card :project="$project" />
+            {{-- Navigation Tabs --}}
+            <div class="w-full">
+                <x-tabs wire:model="activeTab" class="mb-0">
+                    <x-tab name="description" label="Description">
+                        <div class="pt-4">
+                            <x-project-show-description :project="$project" />
+                        </div>
+                    </x-tab>
+                    <x-tab name="versions" label="Versions">
+                        <div class="pt-4">
+                            <x-project-show-versions
+                                :project="$project"
+                                :versions="$versions"
+                                :sort-by="$sortBy"
+                                :version-tag-groups="$this->versionTagGroups"
+                                :release-date-period="$this->releaseDatePeriod"
+                            />
+                        </div>
+                    </x-tab>
+                    <x-tab name="changelog" label="Changelog">
+                        <div class="pt-4">
+                            <x-project-show-changelog :versions="$changelogVersions" />
+                        </div>
+                    </x-tab>
+                </x-tabs>
             </div>
-
-            <!-- Navigation Tabs -->
-            <x-tabs wire:model="activeTab" class="mb-6">
-                <x-tab name="description" label="Description">
-                    <x-project-show-description :project="$project" />
-                </x-tab>
-                <x-tab name="versions" label="Versions">
-                    <x-project-show-versions
-                        :project="$project"
-                        :versions="$versions"
-                        :sort-by="$sortBy"
-                        :version-tag-groups="$this->versionTagGroups"
-                        :release-date-period="$this->releaseDatePeriod"
-                    />
-                </x-tab>
-                <x-tab name="changelog" label="Changelog">
-                    <x-project-show-changelog :versions="$changelogVersions" />
-                </x-tab>
-            </x-tabs>
         </div>
 
-        <!-- Right Column - Sidebar -->
-        <div class="lg:col-span-4 space-y-6">
-            <!-- Versions Section -->
+        {{-- Right Column / Sidebar --}}
+        {{-- On mobile: shown after main content. On lg: side column. --}}
+        <div class="lg:col-span-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
             <x-project-recent-versions :project="$project" />
-
-            <!-- Creators Section -->
             <x-project-creators :project="$project" />
-
-            <!-- External Credits Section -->
             <x-project-external-credits :project="$project" />
-
-            <!-- Links Section -->
             <x-project-links :project="$project" />
         </div>
     </div>

--- a/src/tests/Feature/Project/Livewire/ProjectShowTest.php
+++ b/src/tests/Feature/Project/Livewire/ProjectShowTest.php
@@ -459,7 +459,7 @@ class ProjectShowTest extends TestCase
         Livewire::actingAs($user)
             ->test(ProjectShow::class, ['project' => $project->slug])
             ->assertSee('Creators')
-            ->assertSee('External Credits')
+            ->assertSee('Credits')
             ->assertSee('Jane Doe')
             ->assertSee('Composer');
     }


### PR DESCRIPTION
Reorganize the project show layout for better mobile and desktop usability by tightening spacing, updating grid behavior, and stacking content more predictably.

Add compact action controls with mobile icon-only variants for upload and edit, and normalize button sizing in the top action bar.

Move status alerts to the top of the page and adjust tab and content spacing so project state and navigation are easier to scan.